### PR TITLE
Put #cloud-config in the first line of the file so cloud-init can work correctly

### DIFF
--- a/terramino_app.yaml
+++ b/terramino_app.yaml
@@ -1,7 +1,7 @@
+#cloud-config
 # Copyright (c) HashiCorp, Inc.
 # SPDX-License-Identifier: MIT
 
-#cloud-config
 groups:
   - ubuntu: [root,sys]
   - hashicorp


### PR DESCRIPTION
Put #cloud-config in the first line of the file, and after this put the Copyright and License Headers.

The #cloud-config must be in the first line so the cloud-init can work correctly. Ref: https://cloudinit.readthedocs.io/en/latest/reference/examples.html